### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Follow the steps below to build ReVanced Manager downloader template:
 
 ## 📜 License
 
-ReVanced Manager downloader template is licensed under the GPLv3 licence.
+ReVanced Manager downloader template is licensed under the GPLv3 license.
 Please see the [license file](LICENSE) for more information.
 [tl;dr](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3) you may copy, distribute
 and modify ReVanced Manager downloader template as long as you track changes/dates in source files.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Follow the steps below to build ReVanced Manager downloader template:
 > gpr.key = key
 > ```
 
-## 📜 Licence
+## 📜 License
 
 ReVanced Manager downloader template is licensed under the GPLv3 licence.
 Please see the [license file](LICENSE) for more information.


### PR DESCRIPTION
This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!